### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -14,6 +14,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v7.1.1
+      - uses: release-drafter/release-drafter@v7.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Cache dependencies
-        uses: actions/cache@v5.0.4
+        uses: actions/cache@v5.0.5
         with:
             path: ~/.composer/cache/files
             key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v5.0.5](https://github.com/actions/cache/releases/tag/v5.0.5)** on 2026-04-13T15:57:52Z
* **[release-drafter/release-drafter](https://github.com/release-drafter/release-drafter)** published a new release **[v7.2.1](https://github.com/release-drafter/release-drafter/releases/tag/v7.2.1)** on 2026-04-29T19:28:06Z
